### PR TITLE
Feature to pause and resume replication

### DIFF
--- a/src/core/internal_rest_apis.py
+++ b/src/core/internal_rest_apis.py
@@ -267,3 +267,43 @@ def _set_tables_in_dr_config(
         json=disaster_recovery_set_tables_form_data,
         headers=auth_config["API_HEADERS"],
     ).json()
+
+
+def _pause_xcluster_config(customer_uuid: str, xcluster_config_uuid: str):
+    """
+    Pauses the underlying xCluster replication.
+
+    See also:
+     - https://api-docs.yugabyte.com/docs/yugabyte-platform/3d17ffa45a16e-edit-xcluster-config
+     - https://api-docs.yugabyte.com/docs/yugabyte-platform/64d854c13e51b-ybp-task
+
+    :param customer_uuid: str - the Customer UUID
+    :param xcluster_config_uuid: str - the xCluster config UUID to pause
+    :return: json of YBPTask (it may be passed to wait_for_task)
+    """
+    xcluster_replication_edit_form_data = {"status": "Paused"}
+    return requests.put(
+        url=f"{auth_config['YBA_URL']}/api/v1/customers/{customer_uuid}/xcluster_configs/{xcluster_config_uuid}",
+        json=xcluster_replication_edit_form_data,
+        headers=auth_config["API_HEADERS"],
+    ).json()
+
+
+def _resume_xcluster_config(customer_uuid: str, xcluster_config_uuid: str):
+    """
+    Resumes the underlying xCluster replication.
+
+    See also:
+     - https://api-docs.yugabyte.com/docs/yugabyte-platform/3d17ffa45a16e-edit-xcluster-config
+     - https://api-docs.yugabyte.com/docs/yugabyte-platform/64d854c13e51b-ybp-task
+
+    :param customer_uuid: str - the Customer UUID
+    :param xcluster_config_uuid: str - the xCluster config UUID to resume
+    :return: json of YBPTask (it may be passed to wait_for_task)
+    """
+    xcluster_replication_edit_form_data = {"status": "Running"}
+    return requests.put(
+        url=f"{auth_config['YBA_URL']}/api/v1/customers/{customer_uuid}/xcluster_configs/{xcluster_config_uuid}",
+        json=xcluster_replication_edit_form_data,
+        headers=auth_config["API_HEADERS"],
+    ).json()

--- a/src/mainapp.py
+++ b/src/mainapp.py
@@ -1,7 +1,7 @@
+import yaml
+
 import typer
 from typing import List
-
-import yaml
 
 from pathlib import Path
 from pprint import pprint
@@ -17,6 +17,8 @@ from xclusterdr.manage_dr_cluster import (
     get_source_xcluster_dr_config,
     get_xcluster_dr_available_tables,
     add_tables_to_xcluster_dr,
+    pause_xcluster,
+    resume_xcluster,
 )
 
 suppress_warnings()
@@ -130,11 +132,61 @@ def get_xcluster_configuration_info(
     xcluster_source_name: Annotated[
         str, typer.Argument(default_factory=get_xcluster_source_name)
     ],
+    key: Annotated[
+        str,
+        typer.Option(
+            help="A single key to return the value from the DR config (example: paused)",
+        ),
+    ] = "all",
 ):
     """
-    Show existing xcluster dr configuration info for the source universe
+    Show existing xcluster dr configuration info for the source universe; use --key option to show a single value from the whole config
     """
-    pprint(get_source_xcluster_dr_config(customer_uuid, xcluster_source_name))
+    pprint(get_source_xcluster_dr_config(customer_uuid, xcluster_source_name, key))
+
+
+@app.command("do-pause-xcluster", rich_help_panel="xCluster DR Replication Utilities")
+def do_pause_xcluster(
+    force: Annotated[
+        bool,
+        typer.Option(
+            prompt="Are you sure you want to pause the replication for these clusters?"
+        ),
+    ],
+    customer_uuid: Annotated[str, typer.Argument(default_factory=get_customer_uuid)],
+    xcluster_source_name: Annotated[
+        str, typer.Argument(default_factory=get_xcluster_source_name)
+    ],
+):
+    """
+    Pause the running xcluster replication
+    """
+    if force:
+        return pause_xcluster(customer_uuid, xcluster_source_name)
+    else:
+        print("Operation cancelled")
+
+
+@app.command("do-resume-xcluster", rich_help_panel="xCluster DR Replication Utilities")
+def do_resume_xcluster(
+    force: Annotated[
+        bool,
+        typer.Option(
+            prompt="Are you sure you want to resume the replication for these clusters?"
+        ),
+    ],
+    customer_uuid: Annotated[str, typer.Argument(default_factory=get_customer_uuid)],
+    xcluster_source_name: Annotated[
+        str, typer.Argument(default_factory=get_xcluster_source_name)
+    ],
+):
+    """
+    Resume the running xcluster replication
+    """
+    if force:
+        return resume_xcluster(customer_uuid, xcluster_source_name)
+    else:
+        print("Operation cancelled")
 
 
 @app.command("do-add-tables-to-dr", rich_help_panel="xCluster DR Replication Utilities")


### PR DESCRIPTION
Adds two new features:

- do-pause-xcluster: Pause replication between the two configured universes. After it is paused, the configuration is checked to confirm the value of the "paused" key.
- do-resume-xcluster: Resume replication between the two configured universes. After it is resumed, the configuration is checked to confirm the value of the "paused" key.

To support the confirmation printout, get-dr-config was refactored to allow printing of a single key instead of the whole json.