### PR TITLE
Feature to switchover replication between universes in xcluster dr config

### DIFF
--- a/src/core/internal_rest_apis.py
+++ b/src/core/internal_rest_apis.py
@@ -307,3 +307,34 @@ def _resume_xcluster_config(customer_uuid: str, xcluster_config_uuid: str):
         json=xcluster_replication_edit_form_data,
         headers=auth_config["API_HEADERS"],
     ).json()
+
+
+def _switchover_xcluster_dr(
+    customer_uuid: str,
+    dr_config_uuid: str,
+    primary_universe_uuid: str,
+    dr_replica_universe_uuid: str,
+):
+    """
+    Initiates an xCluster DR planned switchover.
+
+    See also:
+     - https://api-docs.yugabyte.com/docs/yugabyte-platform/branches/2.20/066dda1e654a3-switchover-a-disaster-recovery-config
+     - https://api-docs.yugabyte.com/docs/yugabyte-platform/64d854c13e51b-ybp-task
+
+    :param customer_uuid: str - the Customer UUID
+    :param dr_config_uuid: str - the DR config UUID to use
+    :param primary_universe_uuid: str - the primary Universe UUID
+    :param dr_replica_universe_uuid: str - the secondary (replica) Universe UUID
+    :return: json of YBPTask (it may be passed to wait_for_task)
+    """
+    disaster_recovery_switchover_form_data = {
+        "primaryUniverseUuid": primary_universe_uuid,
+        "drReplicaUniverseUuid": dr_replica_universe_uuid,
+    }
+
+    return requests.post(
+        url=f"{auth_config['YBA_URL']}/api/v1/customers/{customer_uuid}/dr_configs/{dr_config_uuid}/switchover",
+        json=disaster_recovery_switchover_form_data,
+        headers=auth_config["API_HEADERS"],
+    ).json()

--- a/src/mainapp.py
+++ b/src/mainapp.py
@@ -19,6 +19,7 @@ from xclusterdr.manage_dr_cluster import (
     add_tables_to_xcluster_dr,
     pause_xcluster,
     resume_xcluster,
+    perform_xcluster_dr_switchover,
 )
 
 suppress_warnings()
@@ -212,6 +213,28 @@ def do_add_tables_to_dr(
         )
     else:
         print("Please provide table IDs. Operation cancelled.")
+
+
+@app.command("do-switchover", rich_help_panel="xCluster DR Replication Utilities")
+def do_switchover(
+    force: Annotated[
+        bool,
+        typer.Option(
+            prompt="Are you sure you want to switchover the replication for these clusters?"
+        ),
+    ],
+    customer_uuid: Annotated[str, typer.Argument(default_factory=get_customer_uuid)],
+    xcluster_source_name: Annotated[
+        str, typer.Argument(default_factory=get_xcluster_source_name)
+    ],
+):
+    """
+    Switchover the running xcluster replication
+    """
+    if force:
+        return perform_xcluster_dr_switchover(customer_uuid, xcluster_source_name)
+    else:
+        print("Operation cancelled")
 
 
 ## the app callback


### PR DESCRIPTION
Adds one new feature:

- do-switchover: gracefully switches direction of replication stream between universes configured in an xcluster dr relationship. 