### PR TITLE
Add observability: replication state and status

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ By default, this will show all of the xCluster DR settings in json. You can use 
 
 `--key tableType`: indicates which API is used for these universes (YCQL or YSQL)
 
+See also the `obs-status` command.
+
 #### xCluster DR management
 
 ##### do-pause-xcluster         
@@ -126,6 +128,55 @@ Displays the following metrics:
 - estimated amount of potential data loss on *failover* (remember failover is urgent, unlike the graceful switchover)
 
 See https://docs.yugabyte.com/v2.20/yugabyte-platform/back-up-restore-universes/disaster-recovery/disaster-recovery-setup/#metrics for detailed definitions of these metrics.
+
+##### obs-status
+
+Displays the state, status, primaryUniverseState, drReplicaUniverseState, and paused values from the xcluster DR config.
+
+`state` values (status of the DR configuration)
+
+`state: Initializing` - DR replication is being initialized between source and target
+`state: Replicating` - DR replication has been established between source and target
+`state: Switchover in Progress` - the replication stream is in the process of switching over
+`state: Failover in Progress` - the replication stream is in the process of failing over
+`state: Halted` - DR replication was halted during failover because data is not in sync between source and target
+`state: Error` - an error was experienced during replication (re)configuration
+
+`status` values (status of the DR replication stream)
+
+`status: Initialized` - the configuration has been applied, but replication is not yet running
+`status: Running` - the configured DR xcluster replication is running (but may be paused)
+`status: Updating` - the DR xcluster configuration is being changed for this stream
+`status: DeletedUniverse` - either the source or the target has been force-deleted
+`status: DeletionFailed` - removing the async replication config has failed
+`status: Failed` - an error was experienced during replication (re)configuration
+
+`primaryUniverseState` (status of the source side of the replication stream)
+
+`primaryUniverseState: Unconfigured for DR` - this universe is not part of an xcluster DR configuration 
+`primaryUniverseState: Ready to replicate` - checkpoints have been established on the source tables
+`primaryUniverseState: Waiting for DR` - before bootstrapping, the source is waiting for a configured time to give the target time to drop the database to be replicated (if present)
+`primaryUniverseState: Replicating data` - source is sending data to target without issue
+`primaryUniverseState: Preparing for switchover` - source is waiting for all remaining changes to be replicated to target
+`primaryUniverseState: Switching to DR replica` - DR configuration is changing to make this the target
+`primaryUniverseState: Universe marked as DR failed` - a repair is required to restore the DR replication, probably after failover
+
+`drReplicaUniverseState` (status of the target side of the replication stream)
+
+`drReplicaUniverseState: Unconfigured for DR` - this universe is not part of an xcluster DR configuration
+`drReplicaUniverseState: Bootstrapping` - a full copy (backup/restore) is being done from the source
+`drReplicaUniverseState: Receiving data, Ready for reads` - target is receiving data from source without issue
+`drReplicaUniverseState: Switching to DR primary` - DR configuration is changing to make this the source
+`drReplicaUniverseState: Universe marked as DR failed` - a repair is required to restore the DR replication, probably after failover
+
+`paused`
+
+`paused: True` - DR replication has been paused, and no data is being replicated between source and target
+`paused: False` - DR replication has not been paused (has never been paused or was resumed after being paused), and so data is being replicated between source and target
+
+Notes:
+1. The replication state, status, etc. (in particular status="Running" doesn't change if the replication is paused).
+2. The replication state, status, etc. don't change if a universe itself is paused.
 
 ## Roadmap
 

--- a/src/mainapp.py
+++ b/src/mainapp.py
@@ -23,7 +23,7 @@ from xclusterdr.manage_dr_cluster import (
     perform_xcluster_dr_recovery,
 )
 from xclusterdr.common import get_source_xcluster_dr_config
-from xclusterdr.observability import get_xcluster_dr_safetimes
+from xclusterdr.observability import get_xcluster_dr_safetimes, get_status
 
 suppress_warnings()
 
@@ -325,6 +325,19 @@ def get_observability_safetime_lag(
     Retrieve latency and safetime metrics
     """
     print(get_xcluster_dr_safetimes(customer_uuid, xcluster_source_name))
+
+
+@app.command("obs-status", rich_help_panel="xCluster DR Replication Observability")
+def get_observability_status(
+    customer_uuid: Annotated[str, typer.Argument(default_factory=get_customer_uuid)],
+    xcluster_source_name: Annotated[
+        str, typer.Argument(default_factory=get_xcluster_source_name)
+    ],
+):
+    """
+    Retrieve status, state, etc.
+    """
+    print(get_status(customer_uuid, xcluster_source_name))
 
 
 ## the app callback

--- a/src/xclusterdr/observability.py
+++ b/src/xclusterdr/observability.py
@@ -3,7 +3,10 @@ import tabulate
 import datetime
 import pytz
 
-from core.internal_rest_apis import _get_xcluster_dr_safetime, _get_universe_by_name
+from core.internal_rest_apis import (
+    _get_xcluster_dr_safetime,
+    _get_universe_by_name,
+)
 from xclusterdr.common import get_source_xcluster_dr_config
 
 
@@ -56,3 +59,28 @@ def get_xcluster_dr_safetimes(customer_uuid: str, source_universe_name: str):
             floatfmt=".3f",
             showindex=False,
         )
+
+
+def get_status(customer_uuid: str, source_universe_name: str):
+
+    get_source_universe_response = _get_universe_by_name(
+        customer_uuid, source_universe_name
+    )
+    source_universe_details = next(iter(get_source_universe_response), None)
+    if source_universe_details is None:
+        raise RuntimeError(
+            f"ERROR: the universe '{source_universe_name}' was not found."
+        )
+
+    else:
+
+        status_list = get_source_xcluster_dr_config(
+            customer_uuid, source_universe_name, "all"
+        )
+
+        print("configuration: " + status_list["state"])
+        print("replication: " + status_list["status"])
+        print("paused? " + str(status_list["paused"]))
+        print("source: " + status_list["primaryUniverseState"])
+        print("target: " + status_list["drReplicaUniverseState"])
+        return "Please see the README file for interpretation of these results."


### PR DESCRIPTION
Add function to show:

- status of xcluster DR configuration
- status of xcluster DR replication
- status of xcluster DR replication from the perspective of the source universe
- status of xcluster DR replication from the perspective of the target universe
- status of xcluster DR replication paused or not

And the README docs to interpret the output.