### PR TITLE
Remove auto-completion options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# Oh, mac
+.DS_Store
+
 # app-specific
 auth.yaml
 universe.yaml

--- a/src/mainapp.py
+++ b/src/mainapp.py
@@ -27,7 +27,7 @@ from xclusterdr.observability import get_xcluster_dr_safetimes, get_status
 
 suppress_warnings()
 
-app = typer.Typer(no_args_is_help=True, rich_markup_mode="rich")
+app = typer.Typer(no_args_is_help=True, rich_markup_mode="rich", add_completion=False)
 state = {"verbose": False}
 
 # get universe config values


### PR DESCRIPTION
Removed auto-completion options in typer because they are not used in these examples, and are confusing to the user.

If a user wants to use auto-completion, see this typer doc:
https://typer.tiangolo.com/tutorial/commands/?h=install+completion#cli-application-completion 