### PR TITLE
Allow for configurable backup location

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Any of the following commands can be issued via this tool, or via the YBA platfo
 #### xCluster DR setup
 
 ##### setup-dr                  
-Create an xCluster DR configuration. Update `config/universe.yaml` and `config/auth.yaml` with the related platform and universe values.
+Create an xCluster DR configuration. Update `config/universe.yaml` and `config/auth.yaml` with the related platform, universe, database, and backup location values.
 
 ##### get-dr-config             
 Show existing xCluster DR configuration info for the source universe. 

--- a/config/universe_example.yaml
+++ b/config/universe_example.yaml
@@ -1,3 +1,4 @@
 XCLUSTER_SOURCE: "source-universe-name"
 XCLUSTER_TARGET: "target-universe-name"
 REPLICATE_DATABASE_NAMES: { "database-name" }
+SHARED_BACKUP_LOCATION: "human-friendly-name-of-configured-backup-location"

--- a/src/core/internal_rest_apis.py
+++ b/src/core/internal_rest_apis.py
@@ -63,7 +63,26 @@ def _get_session_info():
     ).json()
 
 
-def _get_configs_by_type(customer_uuid: str, config_type: str):
+# def _get_configs_by_type(customer_uuid: str, config_type: str):
+#     """
+#     Return a Customer's configs of a specific config type. This is useful for getting things like the STORAGE configs.
+
+#     See also:
+#      - https://api-docs.yugabyte.com/docs/yugabyte-platform/d09c43e4a8bfd-list-all-customer-configurations
+#      - https://api-docs.yugabyte.com/docs/yugabyte-platform/0e51caecbdf07-customer-config
+
+#     :param customer_uuid: str - the customer UUID
+#     :param config_type: enum<str> - the config type (of STORAGE, ALERTS, CALLHOME, PASSWORD_POLICY).
+#     :return: json array of CustomerConfig
+#     """
+#     response = requests.get(
+#         url=f"{auth_config['YBA_URL']}/api/v1/customers/{customer_uuid}/configs",
+#         headers=auth_config["API_HEADERS"],
+#     ).json()
+#     return list(filter(lambda config: config["type"] == config_type, response))
+
+
+def _get_backup_UUID_by_name(customer_uuid: str, config_name: str):
     """
     Return a Customer's configs of a specific config type. This is useful for getting things like the STORAGE configs.
 
@@ -79,7 +98,7 @@ def _get_configs_by_type(customer_uuid: str, config_type: str):
         url=f"{auth_config['YBA_URL']}/api/v1/customers/{customer_uuid}/configs",
         headers=auth_config["API_HEADERS"],
     ).json()
-    return list(filter(lambda config: config["type"] == config_type, response))
+    return list(filter(lambda config: config["configName"] == config_name, response))
 
 
 def _get_task_status(customer_uuid: str, task_uuid: str) -> json:

--- a/src/mainapp.py
+++ b/src/mainapp.py
@@ -54,6 +54,13 @@ def get_xcluster_replicate_database_names():
     return replicate_database_names
 
 
+def get_xcluster_shared_backup_location():
+    demo_config_file = Path("config/universe.yaml")
+    demo_config_data = yaml.safe_load(demo_config_file.read_text())
+    shared_backup_location = demo_config_data["SHARED_BACKUP_LOCATION"]
+    return shared_backup_location
+
+
 # get auth config values
 
 
@@ -102,6 +109,9 @@ def create_xluster_dr_configuration(
     replicate_database_names: Annotated[
         str, typer.Argument(default_factory=get_xcluster_replicate_database_names)
     ],
+    shared_backup_location: Annotated[
+        str, typer.Argument(default_factory=get_xcluster_shared_backup_location)
+    ],
 ):
     """
     Create an xCluster DR configuration
@@ -111,6 +121,7 @@ def create_xluster_dr_configuration(
         xcluster_source_name,
         xcluster_target_name,
         replicate_database_names,
+        shared_backup_location,
     )
 
 

--- a/src/xclusterdr/manage_dr_cluster.py
+++ b/src/xclusterdr/manage_dr_cluster.py
@@ -2,7 +2,6 @@ import tabulate
 
 from core.internal_rest_apis import (
     _get_all_ysql_tables_list,
-    _get_configs_by_type,
     _get_universe_by_name,
     _get_database_namespaces,
     _create_dr_config,
@@ -13,6 +12,7 @@ from core.internal_rest_apis import (
     _failover_xcluster_dr,
     _get_xcluster_dr_safetime,
     _recover_xcluster_dr_config,
+    _get_backup_UUID_by_name,
 )
 from core.get_universe_info import get_universe_uuid_by_name
 from core.manage_tasks import wait_for_task
@@ -84,16 +84,17 @@ def create_xcluster_dr(
     source_universe_name: str,
     target_universe_name: str,
     db_names: set,
+    backup_location: str,
 ):
 
-    storage_configs = _get_configs_by_type(customer_uuid, "STORAGE")
-
+    storage_configs = _get_backup_UUID_by_name(customer_uuid, backup_location)
     if len(storage_configs) < 1:
         raise RuntimeError(
-            "WARN: no storage configs found, at least one is required for xCluster DR setup."
+            f"ERROR: The backup location '{backup_location}' was not found"
         )
 
-    storage_config_uuid = storage_configs[1]["configUUID"]
+    else:
+        storage_config_uuid = storage_configs[0]["configUUID"]
 
     get_source_universe_response = _get_universe_by_name(
         customer_uuid, source_universe_name


### PR DESCRIPTION
The MVP version of the dr setup command used the first backup storage config.

This version allows for configurable backup location, in config/universe.yaml.

(The backup location has to be accessible from both the source and the target, and is used to do backup/restore to the target during initial and any subsequent bootstrapping.)