### PR TITLE
Add observability: source and target universes from provided universe name

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Use common sense and good development practices when testing and preparing to ru
         - [xCluster DR observability](#xcluster-dr-observability)
             - [obs-latency](#obs-latency)
             - [obs-status](#obs-status)
+            - [obs-xcluster](#obs-xcluster)
 - [Roadmap](#roadmap)
 
 ## Notes on using this for xCluster DR
@@ -163,6 +164,11 @@ Notes:
 1. The replication state, status, etc. (in particular status="Running" doesn't change if the replication is paused).
 2. The replication state, status, etc. don't change if a universe itself is paused.
 
+##### obs-xcluster
+Given a universe name, determine if it is a source, target, or neither. If it is a source, show the target universe name. If it is a target, show the source universe name.
+
+Use the `--universe-name` flag to bypass providing this value interactively.
+
 ## Roadmap
 
 Please submit an issue for any requests for features or relative prioritization.
@@ -177,8 +183,9 @@ See closed pull requests for more detail on completed items.
 - [ ] Return 0 on successful completion; non-zero on failure for non-interactive mode
 - [ ] All parameters have default values
 - [ ] Flag to redirect output to a log file / general logging 
-- [ ] Add backup location to configuration 
+- [x] Add backup location to configuration 
 - [ ] Add example syntax to all commands
+- [ ] Refactor functions to use dynamic source detection instead of configured value
 
 ### xCluster DR
 - [x] Establish replication between universes
@@ -191,7 +198,7 @@ See closed pull requests for more detail on completed items.
 - [ ] Remove replication between universes
 - [x] Observability: safetime lag
 - [x] Observability: status (paused/running and status)
-- [ ] Observability: current primary
+- [x] Observability: current primary
 - [ ] Replication lag every x (configurable) seconds
 - [ ] View replicated tables
 - [ ] Remove tables from replication

--- a/src/core/internal_rest_apis.py
+++ b/src/core/internal_rest_apis.py
@@ -8,7 +8,7 @@ auth_config = get_auth_config()
 
 def _get_universe_by_name(customer_uuid: str, universe_name: str):
     """
-    Basic function that returns a universe by its friendly name.
+    Basic function that returns the details of a universe by its friendly name.
 
     See also:
      - https://api-docs.yugabyte.com/docs/yugabyte-platform/66e50c174046d-list-universes
@@ -20,6 +20,20 @@ def _get_universe_by_name(customer_uuid: str, universe_name: str):
     """
     return requests.get(
         url=f"{auth_config['YBA_URL']}/api/v1/customers/{customer_uuid}/universes?name={universe_name}",
+        headers=auth_config["API_HEADERS"],
+    ).json()
+
+
+def _get_universe_by_uuid(customer_uuid: str, universe_uuid: str):
+    """
+    Basic function that returns a universe by its UUID.
+
+    See also:
+    - https://api-docs.yugabyte.com/docs/yugabyte-platform/73fba4c90fb69-get-a-universe
+    """
+
+    return requests.get(
+        url=f"{auth_config['YBA_URL']}/api/v1/customers/{customer_uuid}/universes/{universe_uuid}",
         headers=auth_config["API_HEADERS"],
     ).json()
 

--- a/src/mainapp.py
+++ b/src/mainapp.py
@@ -11,7 +11,9 @@ from core.internal_rest_apis import (
     _get_session_info,
 )
 from core.get_universe_info import get_universe_uuid_by_name
+
 from includes.overrides import suppress_warnings
+
 from xclusterdr.manage_dr_cluster import (
     create_xcluster_dr,
     get_xcluster_dr_available_tables,
@@ -23,7 +25,12 @@ from xclusterdr.manage_dr_cluster import (
     perform_xcluster_dr_recovery,
 )
 from xclusterdr.common import get_source_xcluster_dr_config
-from xclusterdr.observability import get_xcluster_dr_safetimes, get_status
+
+from xclusterdr.observability import (
+    get_xcluster_dr_safetimes,
+    get_status,
+    get_xcluster_details_by_name,
+)
 
 suppress_warnings()
 
@@ -349,6 +356,20 @@ def get_observability_status(
     Retrieve status, state, etc.
     """
     print(get_status(customer_uuid, xcluster_source_name))
+
+
+@app.command("obs-xcluster", rich_help_panel="xCluster DR Replication Observability")
+def get_xcluster_details_by_universe_name(
+    customer_uuid: Annotated[str, typer.Argument(default_factory=get_customer_uuid)],
+    universe_name: Annotated[
+        str,
+        typer.Option(prompt="Please provide the name of the universe"),
+    ],
+):
+    """
+    Show existing xCluster DR configuration info for a given universe
+    """
+    return get_xcluster_details_by_name(customer_uuid, universe_name)
 
 
 ## the app callback

--- a/src/xclusterdr/observability.py
+++ b/src/xclusterdr/observability.py
@@ -7,7 +7,10 @@ import yaml
 from core.internal_rest_apis import (
     _get_xcluster_dr_safetime,
     _get_universe_by_name,
+    _get_universe_by_uuid,
+    _get_xcluster_dr_configs,
 )
+
 from xclusterdr.common import get_source_xcluster_dr_config
 
 
@@ -116,3 +119,56 @@ def get_status(customer_uuid: str, source_universe_name: str):
         print(f"target: {drReplicaUniverseState} - {target_tooltip}")
 
         return "Please see the README file for further notes on these status fields."
+
+
+def get_xcluster_details_by_name(customer_uuid: str, universe_name: str) -> str:
+    """
+    Helper function to return xCluster details of the universe from a given friendly name.
+
+    :param customer_uuid: str - the customer UUID
+    :param universe_name: str - the universe's friendly name
+    :raises RuntimeError: if the universe is not found
+    """
+    universe = next(iter(_get_universe_by_name(customer_uuid, universe_name)), None)
+
+    if universe is None:
+        raise RuntimeError(
+            f"ERROR: failed to find a universe '{universe_name}' by name"
+        )
+    else:
+        source_config_UUID = universe["drConfigUuidsAsSource"]
+        target_config_UUID = universe["drConfigUuidsAsTarget"]
+
+        if len(source_config_UUID) > 0:
+
+            target_uuid_in_this_xcluster_config = _get_xcluster_dr_configs(
+                customer_uuid, source_config_UUID[0]
+            )["drReplicaUniverseUuid"]
+
+            target_name_in_this_xcluster_config = _get_universe_by_uuid(
+                customer_uuid, target_uuid_in_this_xcluster_config
+            )["name"]
+
+            print(
+                f"This universe is a source, and the target universe is: {target_name_in_this_xcluster_config}"
+            )
+
+        elif len(target_config_UUID) > 0:
+
+            source_uuid_in_this_xcluster_config = _get_xcluster_dr_configs(
+                customer_uuid, target_config_UUID[0]
+            )["primaryUniverseUuid"]
+
+            source_name_in_this_xcluster_config = _get_universe_by_uuid(
+                customer_uuid, source_uuid_in_this_xcluster_config
+            )["name"]
+
+            print(
+                f"This universe is a target, and the source universe is: {source_name_in_this_xcluster_config}"
+            )
+
+        else:
+
+            raise RuntimeError(
+                f"ERROR: '{universe_name}' is not configured as part of an xCluster config."
+            )


### PR DESCRIPTION
Add feature to do this: Given a universe name, determine if it is a source, target, or neither. If it is a source, show the target universe name. If it is a target, show the source universe name.