### PR TITLE
Add feature to remove an existing DR config between universes

### DIFF
--- a/src/core/internal_rest_apis.py
+++ b/src/core/internal_rest_apis.py
@@ -257,6 +257,28 @@ def _create_dr_config(
     ).json()
 
 
+def _delete_xcluster_dr_config(
+    customer_uuid: str, dr_config_uuid: str, is_force_delete=False
+):
+    """
+    Deletes an existing xCluster DR config.
+
+    See also:
+     - https://api-docs.yugabyte.com/docs/yugabyte-platform/branches/2.20/defcf45434fc0-delete-xcluster-config
+     - https://api-docs.yugabyte.com/docs/yugabyte-platform/64d854c13e51b-ybp-task
+
+    :param customer_uuid: str - the Customer UUID
+    :param dr_config_uuid:  str - the DR config UUID to return
+    :param is_force_delete: bool - whether to force delete the DR config; default False
+    :return: json of YBPTask (it may be passed to wait_for_task)
+    """
+    return requests.delete(
+        url=f"{auth_config['YBA_URL']}/api/v1/customers/{customer_uuid}/dr_configs/{dr_config_uuid}"
+        f"?isForceDelete={json.dumps(is_force_delete)}",
+        headers=auth_config["API_HEADERS"],
+    ).json()
+
+
 def _set_tables_in_dr_config(
     customer_uuid: str,
     dr_config_uuid: str,

--- a/src/mainapp.py
+++ b/src/mainapp.py
@@ -16,6 +16,7 @@ from includes.overrides import suppress_warnings
 
 from xclusterdr.manage_dr_cluster import (
     create_xcluster_dr,
+    delete_xcluster_dr,
     get_xcluster_dr_available_tables,
     add_tables_to_xcluster_dr,
     pause_xcluster,
@@ -129,6 +130,23 @@ def create_xluster_dr_configuration(
         xcluster_target_name,
         replicate_database_names,
         shared_backup_location,
+    )
+
+
+@app.command("remove-dr", rich_help_panel="xCluster DR Replication Setup")
+def create_xluster_dr_configuration(
+    customer_uuid: Annotated[str, typer.Argument(default_factory=get_customer_uuid)],
+    universe_name: Annotated[
+        str,
+        typer.Option(prompt="Please provide the name of the universe"),
+    ],
+):
+    """
+    Remove an xCluster DR configuration
+    """
+    delete_xcluster_dr(
+        customer_uuid,
+        universe_name,
     )
 
 


### PR DESCRIPTION
Add feature to remove an existing DR config between universes.

Requires either the source or target universe name to be provided.