### PR TITLE
Allow three options for command parameters: flags, config file, and interactive input

### DIFF
--- a/config/universe_example.yaml
+++ b/config/universe_example.yaml
@@ -1,4 +1,4 @@
 XCLUSTER_SOURCE: "source-universe-name"
 XCLUSTER_TARGET: "target-universe-name"
-REPLICATE_DATABASE_NAMES: { "database-name" }
-SHARED_BACKUP_LOCATION: "human-friendly-name-of-configured-backup-location"
+REPLICATE_DATABASE_NAMES: "database1,database2"
+SHARED_BACKUP_LOCATION: "name-of-configured-backup-location"

--- a/src/xclusterdr/manage_dr_cluster.py
+++ b/src/xclusterdr/manage_dr_cluster.py
@@ -84,9 +84,11 @@ def create_xcluster_dr(
     customer_uuid: str,
     source_universe_name: str,
     target_universe_name: str,
-    db_names: set,
+    db_names: list,
     backup_location: str,
 ):
+
+    # verify the storage location
 
     storage_configs = _get_backup_UUID_by_name(customer_uuid, backup_location)
     if len(storage_configs) < 1:
@@ -96,6 +98,8 @@ def create_xcluster_dr(
 
     else:
         storage_config_uuid = storage_configs[0]["configUUID"]
+
+    # verify the source universe
 
     get_source_universe_response = _get_universe_by_name(
         customer_uuid, source_universe_name
@@ -119,6 +123,8 @@ def create_xcluster_dr(
             f" {dr_config_source_uuid},"
         )
 
+    # verify the target universe
+
     target_universe_response = _get_universe_by_name(
         customer_uuid, target_universe_name
     )
@@ -131,8 +137,12 @@ def create_xcluster_dr(
 
     target_universe_uuid = target_universe_details["universeUUID"]
 
+    # verify the list of databases
+
     dbs_list = _get_database_namespaces(customer_uuid, source_universe_uuid)
     dbs_list_uuids = [d["namespaceUUID"] for d in dbs_list if d["name"] in db_names]
+
+    # call the api request
 
     create_dr_response = _create_dr_config(
         customer_uuid,
@@ -167,7 +177,7 @@ def delete_xcluster_dr(customer_uuid, source_universe_name) -> str:
     dr_config_source_uuid = next(iter(universe_details["drConfigUuidsAsSource"]), None)
     if dr_config_source_uuid is None:
         raise RuntimeError(
-            f"ERROR: source universe '{source_universe_name}' does not have a disaster-recovery config!"
+            f"ERROR: the universe '{source_universe_name}' is not the source in a disaster-recovery config"
         )
 
     response = _delete_xcluster_dr_config(customer_uuid, dr_config_source_uuid)

--- a/src/xclusterdr/observability.py
+++ b/src/xclusterdr/observability.py
@@ -150,7 +150,7 @@ def get_xcluster_details_by_name(customer_uuid: str, universe_name: str) -> str:
             )["name"]
 
             print(
-                f"This universe is a source, and the target universe is: {target_name_in_this_xcluster_config}"
+                f"{universe_name} universe is a source, and the target universe is: {target_name_in_this_xcluster_config}"
             )
 
         elif len(target_config_UUID) > 0:
@@ -164,7 +164,7 @@ def get_xcluster_details_by_name(customer_uuid: str, universe_name: str) -> str:
             )["name"]
 
             print(
-                f"This universe is a target, and the source universe is: {source_name_in_this_xcluster_config}"
+                f"{universe_name} universe is a target, and the source universe is: {source_name_in_this_xcluster_config}"
             )
 
         else:


### PR DESCRIPTION
Refactor all commands to allow for the following order of checking for parameter values:

1. check for parameter flags
2. read in environment variables from config file
3. take interactive input from user

Update docs to reflect the above.

Add examples for each command.

Simplify code setting environment variables from config files.