### PR TITLE
Correct two example universe names for consistency with config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Pause the running xCluster DR replication.
 
 Example:
 ```
-python src/mainapp.py do-pause-xcluster --xcluster-source-name vparham-dr-left
+python src/mainapp.py do-pause-xcluster --xcluster-source-name source-universe-name
 ```
 
 The verification (True or False) will display at the end of this command output.
@@ -135,7 +135,7 @@ Resume the running xCluster DR replication.
 
 Example:
 ```
-python src/mainapp.py do-resume-xcluster --xcluster-source-name vparham-dr-left
+python src/mainapp.py do-resume-xcluster --xcluster-source-name source-universe-name
 ```
 
 The verification (True or False) will display at the end of this command output.


### PR DESCRIPTION
Minor correction to two example universe names to maintain consistency with config files and within the README.