### PR TITLE
First test ported to pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 
 # Unit test 
 .pytest_cache/
+testing.yaml
 
 # Sphinx documentation
 docs/_build/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Use common sense and good development practices when testing and preparing to ru
             - [obs-latency](#obs-latency)
             - [obs-status](#obs-status)
             - [obs-xcluster](#obs-xcluster)
+- [Testing](#testing)
 - [Roadmap](#roadmap)
 
 ## Notes on using this for xCluster DR
@@ -232,6 +233,19 @@ Example:
 ```
 python src/mainapp.py obs-xcluster --xcluster-source-name source-universe-name
 ```
+
+## Testing
+
+You can use `pytest` to execute the provided tests (test_ files). 
+
+### test cluster configuration
+
+You will likely want to use test universes to run tests, not your production universes. Provide a customer ID (unique to a YBA instance) and universe information in the config/testing.yaml file.
+
+### pytest configuration
+
+The configuration for pytest itself is in pytest.ini. 
+
 
 ## Roadmap
 

--- a/config/testing_example.yaml
+++ b/config/testing_example.yaml
@@ -1,0 +1,2 @@
+CUSTOMER_UUID: "your-customer-id"
+XCLUSTER_SOURCE: "source-universe-name"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+pythonpath = src
+addopts = -v
+filterwarnings = ignore::Warning

--- a/src/test_mainapp.py
+++ b/src/test_mainapp.py
@@ -1,0 +1,31 @@
+import os
+from pathlib import Path
+import pytest
+import re
+import yaml
+
+from mainapp import get_xcluster_configuration_info
+
+# get testing config values
+testing_config_file = Path("config/testing.yaml")
+testing_config_data = yaml.safe_load(testing_config_file.read_text())
+
+if testing_config_data:
+    for key, value in testing_config_data.items():
+        os.environ[key] = str(value)
+
+
+@pytest.mark.parametrize(
+    "key, expected_output",
+    [
+        ("all", "{'bootstrapParams':"),
+        ("paused", "True|False"),
+        ("uuid", "'.{8}-.{4}-.{4}-.{4}-.{12}'"),
+    ],
+)
+def test_get_xcluster_configuration_info(capsys, key, expected_output):
+    get_xcluster_configuration_info(
+        os.environ.get("CUSTOMER_UUID"), os.environ.get("XCLUSTER_SOURCE"), key
+    )
+    captured = capsys.readouterr()
+    assert re.search(expected_output, captured.out) is not None


### PR DESCRIPTION
Port a single test to pytest, for get-dr-config.

To support this:
- Add testing_example.yaml to configure a test universe.
- Add pytest.ini to configure pytest behavior.
- Update README.

Test currently supports "all" key and two other key types as examples.