### PR TITLE
Display all xcluster configurations for this YBA platform (customer ID)

### DIFF
--- a/src/core/internal_rest_apis.py
+++ b/src/core/internal_rest_apis.py
@@ -486,3 +486,18 @@ def _recover_xcluster_dr_config(
         json=disaster_recovery_restart_form_data,
         headers=auth_config["API_HEADERS"],
     ).json()
+
+
+def _list_all_universes(customer_uuid: str):
+    """
+    Lists all universes in a given YBA platform (for a given customer ID)
+
+    See also:
+     - https://api-docs.yugabyte.com/docs/yugabyte-platform/66e50c174046d-list-universes
+
+    :param customer_uuid: str - the Customer UUID
+    """
+    return requests.get(
+        url=f"{auth_config['YBA_URL']}/api/v1/customers/{customer_uuid}/universes",
+        headers=auth_config["API_HEADERS"],
+    ).json()

--- a/src/mainapp.py
+++ b/src/mainapp.py
@@ -2,7 +2,7 @@ import os
 import yaml
 
 import typer
-from typing import List, Optional
+from typing import List
 
 from pprint import pprint
 from typing_extensions import Annotated
@@ -32,7 +32,7 @@ from xclusterdr.common import get_source_xcluster_dr_config
 from xclusterdr.observability import (
     get_xcluster_dr_safetimes,
     get_status,
-    get_xcluster_details_by_name,
+    get_all_clusters,
 )
 
 from healthcheck.map import get_diagram_map
@@ -384,16 +384,15 @@ def get_observability_status(
 
 
 @app.command("obs-xcluster", rich_help_panel="xCluster DR Replication Observability")
-def get_xcluster_details_by_universe_name(
+def get_all_clusters_for_yba(
     customer_uuid: Annotated[
         str, typer.Argument(default_factory=get_customer_uuid, hidden=True)
     ],
-    universe_name: Annotated[str, typer.Option(envvar="XCLUSTER_SOURCE", prompt=True)],
 ):
     """
-    Show existing xCluster DR configuration info for a given universe
+    Show info for all universes
     """
-    return get_xcluster_details_by_name(customer_uuid, universe_name)
+    print(get_all_clusters(customer_uuid))
 
 
 ## app commands: healthcheck


### PR DESCRIPTION
Change the source/target observability command in the following three ways:
- Displays all source/target relationships for the given YBA platform (customer ID)
- Eliminates the need to pass a universe name to the command
- Displays output in a human-readable table

The output of this command can be used to get the source universe for other commands, such as switchover.