### PR TITLE
Get source universe name from either universe name in an xCluster DR configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Use common sense and good development practices when testing and preparing to ru
             - [do-switchover](#do-switchover)
             - [do-failover](#do-failover)
             - [do-recovery](#do-recovery)
+            - [get-source](#get-source)
         - [xCluster DR table management](#xcluster-dr-table-management)
             - [get-tables](#get-tables)
             - [do-add-tables-to-dr](#do-add-tables-to-dr)
@@ -203,6 +204,16 @@ Example:
 python src/mainapp.py do-recovery --current-primary source-universe-name
 ```
 
+##### get-source
+Pass either universe name in an xCluster DR configuration to return the source universe name.
+
+The returned text has no surrounding explanatory wording, as the main use is to get the current source universe name for any given pair in an automation flow.
+
+Example:
+```
+python src/mainapp.py get-source --universe-name a-universe-name
+```
+
 #### xCluster DR table management
 
 ##### get-tables   
@@ -310,6 +321,7 @@ See closed pull requests for more detail on completed items.
 - [x] Ensure user confirms commands that will change the universe and/or replication streams.
 - [x] Pass in configuration file
 - [ ] Allow for local script managing multiple YBA instances
+- [x] Get source universe name from either universe name in an xCluster DR configuration
 
 ### xCluster DR
 - [x] Establish replication between universes

--- a/src/mainapp.py
+++ b/src/mainapp.py
@@ -26,6 +26,7 @@ from xclusterdr.manage_dr_cluster import (
     perform_xcluster_dr_switchover,
     perform_xcluster_dr_failover,
     perform_xcluster_dr_recovery,
+    get_xcluster_details_by_name,
 )
 from xclusterdr.common import get_source_xcluster_dr_config
 
@@ -162,6 +163,19 @@ def get_xcluster_configuration_info(
     Show existing xCluster DR configuration info for the source universe
     """
     pprint(get_source_xcluster_dr_config(customer_uuid, xcluster_source_name, key))
+
+
+@app.command("get-source", rich_help_panel="xCluster DR Replication Setup")
+def get_xcluster_details_by_universe_name(
+    customer_uuid: Annotated[
+        str, typer.Argument(default_factory=get_customer_uuid, hidden=True)
+    ],
+    universe_name: Annotated[str, typer.Option(envvar="XCLUSTER_SOURCE", prompt=True)],
+):
+    """
+    Get source universe name from any universe name
+    """
+    return get_xcluster_details_by_name(customer_uuid, universe_name)
 
 
 ## app commands: xCluster DR replication management

--- a/src/xclusterdr/manage_dr_cluster.py
+++ b/src/xclusterdr/manage_dr_cluster.py
@@ -327,12 +327,6 @@ def get_xcluster_details_by_name(customer_uuid: str, universe_name: str) -> str:
         source_config_UUID = universe["drConfigUuidsAsSource"]
         target_config_UUID = universe["drConfigUuidsAsTarget"]
         if len(source_config_UUID) > 0:
-            # target_uuid_in_this_xcluster_config = _get_xcluster_dr_configs(
-            #     customer_uuid, source_config_UUID[0]
-            # )["drReplicaUniverseUuid"]
-            # target_name_in_this_xcluster_config = _get_universe_by_uuid(
-            #     customer_uuid, target_uuid_in_this_xcluster_config
-            # )["name"]
             print(f"{universe_name}")
         elif len(target_config_UUID) > 0:
             source_uuid_in_this_xcluster_config = _get_xcluster_dr_configs(


### PR DESCRIPTION
Pass either universe name in an xCluster DR configuration to return the source universe name.

The returned text has no surrounding explanatory wording, as the main use is to get the current source universe name for any given pair in an automation flow.

Can pass config file, via --universe-name on command line, or interactively. Best practice for automation is to use the command line flag.